### PR TITLE
Fix/7 interpolation exception compile error

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -340,7 +340,12 @@ void get_next_token(Parser* parser) {
             CASE(';', SEMICOLON)
             CASE('[', LB) CASE(']', RB)
             CASE('{', LC) CASE('}', RC)
-            CASE('(', LP)
+            case '(':
+                if (parser->interpolation_rp_trace > 0) {
+                    parser->interpolation_rp_trace++;
+                }
+                parser->cur_token.type = TOKEN_LP;
+                break;
             case ')':
                 if (parser->interpolation_rp_trace > 0) {
                     parser->interpolation_rp_trace--;

--- a/test/bugfix_issue5.sp
+++ b/test/bugfix_issue5.sp
@@ -1,5 +1,5 @@
 class TestClass {
-    static st_getter -> String {            // expect '{' at the beginning of method body.
+    static st_getter -> String {
         return "this is static getter method.";
     }
 
@@ -11,7 +11,7 @@ class TestClass {
 
     new () {}
 
-    getter -> String {                      // expect '{' at the beginning of method body.
+    getter -> String {
         return "this is getter method.";
     }
 
@@ -23,7 +23,7 @@ class TestClass {
         return "this is method.";
     }
 
-    [_: Any] -> String {                    // expect '{' at the beginning of method body.
+    [_: Any] -> String {
         return "this is subscript method.";
     }
 

--- a/test/bugfix_issue7.sp
+++ b/test/bugfix_issue7.sp
@@ -1,0 +1,20 @@
+class TestClass {
+    static st_getter -> String {
+        return "this is static getter method.";
+    }
+
+    static st_method() -> String {
+        return "this is static method.";
+    }
+}
+
+fn foo() -> String {
+    return "this is function.";
+}
+
+let a = 10;
+
+System.print("%(a)");
+System.print("%(TestClass.st_getter)");
+System.print("%(TestClass.st_method())"); // error: expect string at the end of interpolatation.
+System.print("%(foo())"); // expect string at the end of interpolatation.

--- a/test/bugfix_issue7.sp
+++ b/test/bugfix_issue7.sp
@@ -16,5 +16,5 @@ let a = 10;
 
 System.print("%(a)");
 System.print("%(TestClass.st_getter)");
-System.print("%(TestClass.st_method())"); // error: expect string at the end of interpolatation.
-System.print("%(foo())"); // expect string at the end of interpolatation.
+System.print("%(TestClass.st_method())");
+System.print("%(foo())");


### PR DESCRIPTION
fix #7 修复了这个问题

- 修复了 #7 中报告的问题。问题源自于 parser.c 未能正确追踪内嵌表达式中括号的嵌套层数。
- 提交测试 test/bugfix_issue7.sp 可用于验证 #7 是否正确修复。
- 修改了 test 中的测试文件命名，使其功能更明晰。

Closes #7 
