### PR TITLE
Fix/9 block comment error

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -212,7 +212,7 @@ static void parse_string(Parser* parser) {
 }
 
 // 跳过一行
-static void skip_aline(Parser* parser) {
+inline static void skip_aline(Parser* parser) {
     get_next_char(parser);
     while (parser->cur_char != '\0') {
         if (parser->cur_char == '\n') {
@@ -224,7 +224,7 @@ static void skip_aline(Parser* parser) {
     }
 }
 
-static void skip_comment(Parser* parser) {
+inline static void skip_comment(Parser* parser) {
     // 单行注释
     if (parser->cur_char == '/') {
         skip_aline(parser);
@@ -232,26 +232,27 @@ static void skip_comment(Parser* parser) {
         return;
     }
 
-    char next_char = look_ahead_char(parser);
-    while (next_char != '*' && next_char != '\0') {
+    // cur_char == '*' 块注释
+    get_next_char(parser); // skip '*'
+    char next_char = '\0';
+    while (parser->cur_char != '\0') {
+        if (parser->cur_char == '*' && (next_char = look_ahead_char(parser)) == '/') {
+            break;
+        }
+
         get_next_char(parser);
         
         if (parser->cur_char == '\n') {
             parser->cur_token.line++;
         }
-
-        next_char = look_ahead_char(parser);
     }
 
-    if (next_char == '\0') {
+    if (parser->cur_char == '\0') {
         LEX_ERROR(parser, "expect '*/' before EOF.");
     }
-
-    if (!match_next_char(parser, '*') || !match_next_char(parser, '/')) {
-        LEX_ERROR(parser, "expect '/' after '*'.");
-    }
-
-    get_next_char(parser);
+    
+    get_next_char(parser); // skip '/'
+    get_next_char(parser); // 指向下一个字符
     skip_blanks(parser);
 }
 

--- a/test/test_comment.sp
+++ b/test/test_comment.sp
@@ -1,0 +1,14 @@
+// line comment
+
+/* inline */
+
+/*
+
+mut-line
+
+*/
+
+/**
+ * with style
+ *
+ */


### PR DESCRIPTION
fix #9 修复了块注释中不能使用 '*' 字符的 bug

如题。导致 #9 的原因实际为块注释中未支持 '*' 字符。
修改前的 parser 在块注释中读入 '*' 则认为已到结尾，会导致块注释中不能使用 '*' 符号。
鉴于在块注释中使用 '*' 是一个常见的行为，且 '*' 字符理应允许在块注释中使用，遂修复该问题。

提交了用于测试注释是否可以正确解析的测试用例 `test/test_comments.sp`

为已定义但仅在个别位置调用的的函数 `skip_aline` 与 `skip_comment` 添加 `inline` 标记便于编译器优化。

2025-08-19
Closes #9 