### PR TITLE
fix (core parser) 修复 import_module 中线程切换的错误和字符串转义字符解析错误的问题

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -153,6 +153,12 @@ static void parse_string(Parser* parser) {
             break;
         }
 
+        if (parser->cur_char == '\n') {
+            parser->cur_token.line++;
+            BufferAdd(Byte, &str, parser->vm, parser->cur_char);
+            continue;
+        }
+
         // 内嵌表达式
         if (parser->cur_char == '%') {
             if (!match_next_char(parser, '(')) {
@@ -175,7 +181,6 @@ static void parse_string(Parser* parser) {
             #define match(val) \
                 case #val[0]:\
                     BufferAdd(Byte, &str, parser->vm, ESC_##val);\
-                    get_next_char(parser);\
                     break;
             switch (parser->cur_char) {
                 match(0)
@@ -201,6 +206,7 @@ static void parse_string(Parser* parser) {
                     break;
             }
             #undef match
+            continue;
         }
 
         BufferAdd(Byte, &str, parser->vm, parser->cur_char);

--- a/src/vm/core.c
+++ b/src/vm/core.c
@@ -1899,10 +1899,11 @@ def_prim(System_import_module) {
         RNULL();
     }
 
-    vm->cur_thread--; // 回收args[1]，只保留args[0]用于存放thread返回的结果。
+    vm->cur_thread->esp--; // 回收args[1]，只保留args[0]用于存放thread返回的结果。
 
     ObjThread* next_thread = VALUE_TO_THREAD(res);
     next_thread->caller = vm->cur_thread;
+    vm->cur_thread = next_thread;
     return false; // switch thread
 }
 


### PR DESCRIPTION
本次提交主要在修复 import 语句不能正常使用的问题 #20。parser 中的修复改动很小且没有修改核心逻辑，因此附带提交。

core
- 修复了 import_module 中切换线程的错误操作导致的 import 语句不能正确执行的问题。

parser
- 修复了字符串中转义字符未能正确解析的问题。
- 修复了多行字符串不能正确记录行号的问题。

2025-08-22
Closes #20 