### PR TITLE
feat (core) 添加函数 VM.is_main 判断模块是否是被导入模块

### DIFF
--- a/src/vm/core.c
+++ b/src/vm/core.c
@@ -1955,6 +1955,10 @@ def_prim(VM_allocated_bytes) {
     RI32((int)vm->allocated_bytes);
 }
 
+def_prim(VM_is_main) {
+    RBOOL(vm->cur_thread->caller == NULL);
+}
+
 def_prim(NativePointer_check_classifier) {
     if (!validate_str(vm, args[1])) {
         return false; // error
@@ -2208,6 +2212,7 @@ void build_core(VM* vm) {
     Class* vm_class = VALUE_TO_CLASS(get_core_class_value(core_module, "VM"));
     BIND_PRIM_METHOD(vm_class->header.class, "gc()", prim_name(VM_gc));
     BIND_PRIM_METHOD(vm_class->header.class, "allocated_bytes", prim_name(VM_allocated_bytes));
+    BIND_PRIM_METHOD(vm_class->header.class, "is_main", prim_name(VM_is_main));
 
     vm->native_pointer_class = VALUE_TO_CLASS(get_core_class_value(core_module, "NativePointer"));
     BIND_PRIM_METHOD(vm->native_pointer_class, "check_classifier(_)", prim_name(NativePointer_check_classifier));


### PR DESCRIPTION
为便利对库的单元测试，添加 VM.is_main 用于判断模块是否是直接由 spr 启动。

VM.is_main -> bool;
- 返回 bool 值。若该模块是直接由 spr 启动的（即为 main-script）则返回 true，若由 import 导入或由其他线程拉起则返回 false 。
- 实现细节：判断当前线程 caller 是否为 NULL。

2025-08-22