### PR TITLE
fix (compiler) 修复了 import 表达式未正确生成字节码的问题 #25

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2023,6 +2023,7 @@ static void compile_import_stmt(CompileUnit* cu) {
     emit_load_module_var(cu, "System");
     write_opcode_short_operand(cu, OPCODE_LOAD_CONSTANT, const_name_inedx);
     emit_call(cu, 1, "import_module(_)", 16);
+    write_opcode(cu, OPCODE_POP);
 
     if (match_token(cu->parser, TOKEN_SEMICOLON)) {
         return;


### PR DESCRIPTION
修复了 import 表达式为能正确生成字节码的问题。
issue #25 汇报的问题是由于 import 生成字节码中缺少弹出 System.import_module 结果的 POP 指令，致使栈不平衡，破坏了局部变量正确索引导致的。

2025-08-22
Closes #25