### PR TITLE
Feat/spr std lib

### DIFF
--- a/lib/lcg_random.sp
+++ b/lib/lcg_random.sp
@@ -1,0 +1,21 @@
+class LCGRandom {
+    static let seed: f64 = System.clock(); // 默认初始种子
+
+    static let a: f64 = 1103515245.0;    // 乘数
+    static let c: f64 = 12345.0;         // 增量
+    static let m: f64 = 2147483648.0;    // 模数(2^31)，确保结果在int范围内
+
+    static rand() -> f64 {
+        seed = Math.i32((a * seed + c) % m);
+        return seed / m;
+    }
+
+    static rand_i32(min: i32, max: i32) -> i32 {
+        if (min >= max) {
+            return max; // 区间无效，默认返回max
+        }
+
+        let res: f64 = rand();
+        return min + Math.i32(res * (max - min + 1.0));
+    }
+}

--- a/src/object/class.h
+++ b/src/object/class.h
@@ -40,6 +40,7 @@ typedef enum {
 #define VALUE_IS_UNDEFINED(v)   (v.type == VT_UNDEFINED)
 #define VALUE_IS_FALSE(v)       (v.type == VT_FALSE)
 #define VALUE_IS_TRUE(v)        (v.type == VT_TRUE)
+#define VALUE_IS_BOOL(v)        (VALUE_IS_TRUE(v) || VALUE_IS_FALSE(v))
 #define VALUE_IS_I32(v)         (v.type == VT_I32)
 #define VALUE_IS_F64(v)         (v.type == VT_F64)
 #define VALUE_IS_NULL(v)        (v.type == VT_NULL)

--- a/src/vm/core.c
+++ b/src/vm/core.c
@@ -1801,8 +1801,10 @@ def_prim(Range_new_arg1) {
 }
 
 static char* get_file_path(const char* module_name, bool is_std) {
-    u32 root_dir_len = is_std ? strlen(STD_LIB_PATH) : (root_dir == NULL ? 0 : strlen(root_dir));
-    char* root_path = is_std ? STD_LIB_PATH : root_dir;
+    const char* std_lib_path = getenv("SPR_STD_LIB_PATH")?: getenv("HOME");
+    
+    u32 root_dir_len = is_std ? strlen(std_lib_path) : (root_dir == NULL ? 0 : strlen(root_dir));
+    const char* root_path = is_std ? std_lib_path : root_dir;
     
     u32 name_len = strlen(module_name);
     u32 extension_len = strlen(SCRIPT_EXTENSION);

--- a/src/vm/core.c
+++ b/src/vm/core.c
@@ -23,6 +23,7 @@
 #include "vm.h"
 #include <math.h>
 #include <time.h>
+#include <unistd.h>
 #include "disassemble.h"
 
 #include "core.script.inc"
@@ -506,6 +507,13 @@ inline static bool validate_str(VM* vm, Value arg) {
         return true;
     }
     SET_ERROR_FALSE(vm, "argument must be string.");
+}
+
+inline static bool validate_bool(VM* vm, Value arg) {
+    if (VALUE_IS_BOOL(arg)) {
+        return true;
+    }
+    SET_ERROR_FALSE(vm, "argument must be bool.");
 }
 
 def_prim(f64_from_string) {
@@ -1792,8 +1800,10 @@ def_prim(Range_new_arg1) {
     ROBJ(objrange_new(vm, from, args[1].ival, step));
 }
 
-static char* get_file_path(const char* module_name) {
-    u32 root_dir_len = root_dir == NULL ? 0 : strlen(root_dir);
+static char* get_file_path(const char* module_name, bool is_std) {
+    u32 root_dir_len = is_std ? strlen(STD_LIB_PATH) : (root_dir == NULL ? 0 : strlen(root_dir));
+    char* root_path = is_std ? STD_LIB_PATH : root_dir;
+    
     u32 name_len = strlen(module_name);
     u32 extension_len = strlen(SCRIPT_EXTENSION);
     u32 path_len = root_dir_len + name_len + extension_len;
@@ -1803,8 +1813,8 @@ static char* get_file_path(const char* module_name) {
         MEM_ERROR("memory error when make module path.");
     }
     
-    if (root_dir != NULL) {
-        memmove(path, root_dir, root_dir_len);
+    if (root_path != NULL) {
+        memmove(path, root_path, root_dir_len);
     }
 
     memmove(path + root_dir_len, module_name, name_len);
@@ -1814,8 +1824,8 @@ static char* get_file_path(const char* module_name) {
     return path;
 }
 
-inline static char* read_module(const char* module_name) {
-    char* module_path = get_file_path(module_name);
+inline static char* read_module(const char* module_name, bool is_std) {
+    char* module_path = get_file_path(module_name, is_std);
     char* module_code = read_file(module_path);
     free(module_path);
     return module_code;
@@ -1831,13 +1841,13 @@ inline static void fprint_str(FILE* fp, const char* str) {
     fflush(fp);
 }
 
-static Value import_module(VM* vm, Value module_name) {
+static Value import_module(VM* vm, Value module_name, bool is_std) {
     if (!VALUE_IS_UNDEFINED(objmap_get(vm->all_module, module_name))) {
         return VT_TO_VALUE(VT_NULL);
     }
 
     ObjString* str = VALUE_TO_STRING(module_name);
-    const char* src = read_module(str->val.start);
+    const char* src = read_module(str->val.start, is_std);
 
     ObjThread* module_thread = load_module(vm, module_name, src);
     return OBJ_TO_VALUE(module_thread);
@@ -1894,7 +1904,25 @@ def_prim(System_import_module) {
         return false; // error
     }
 
-    Value res = import_module(vm, args[1]); // 编译module
+    Value res = import_module(vm, args[1], false); // 编译module
+    if (VALUE_IS_NULL(res)) { // module已存在，因此只需要
+        RNULL();
+    }
+
+    vm->cur_thread->esp--; // 回收args[1]，只保留args[0]用于存放thread返回的结果。
+
+    ObjThread* next_thread = VALUE_TO_THREAD(res);
+    next_thread->caller = vm->cur_thread;
+    vm->cur_thread = next_thread;
+    return false; // switch thread
+}
+
+def_prim(System_import_std_module) {
+    if (!validate_str(vm, args[1])) {
+        return false; // error
+    }
+
+    Value res = import_module(vm, args[1], true); // 编译module
     if (VALUE_IS_NULL(res)) { // module已存在，因此只需要
         RNULL();
     }
@@ -2206,6 +2234,7 @@ void build_core(VM* vm) {
     Class* system = VALUE_TO_CLASS(get_core_class_value(core_module, "System"));
     BIND_PRIM_METHOD(system->header.class, "clock()", prim_name(System_clock));
     BIND_PRIM_METHOD(system->header.class, "import_module(_)", prim_name(System_import_module));
+    BIND_PRIM_METHOD(system->header.class, "import_std_module(_)", prim_name(System_import_std_module));
     BIND_PRIM_METHOD(system->header.class, "get_module_variable(_,_)", prim_name(System_get_module_variable));
     BIND_PRIM_METHOD(system->header.class, "write_string(_)", prim_name(System_write_string));
     

--- a/src/vm/core.h
+++ b/src/vm/core.h
@@ -4,7 +4,6 @@
 #include "vm.h"
 #include "class.h"
 
-#define STD_LIB_PATH     "/Users/minglangqingche/sparrow/lib/"
 #define SCRIPT_EXTENSION ".sp"
 
 extern char* root_dir;

--- a/src/vm/core.h
+++ b/src/vm/core.h
@@ -4,6 +4,7 @@
 #include "vm.h"
 #include "class.h"
 
+#define STD_LIB_PATH     "/Users/minglangqingche/sparrow/lib/"
 #define SCRIPT_EXTENSION ".sp"
 
 extern char* root_dir;


### PR DESCRIPTION
为了便于非运行时必须标准库的扩展，避免运行时必须库 core 的代码量继续扩大造成的运行时资源浪费，添加标准库并实现导入标准库模块的功能。

功能介绍
- 通过 `import std.std-file-name for SomeModuleVariable;` 的语法导入标准库中的内容
- 标准库的地址由环境变量 `SPR_STD_LIB_PATH` 指出，若该环境变量为空，则默认为 `HOME` 路径

std-lib
- 仍未实现。提交的 `./lib` 中的文件目前仅用于测试本次提交的功能是否正确，并非标准库内容。

2025-08-22