### PR TITLE
feat (parser ast test) 为 ast-compiler 添加 getter & setter 语法糖

### DIFF
--- a/src/compiler/ast_compiler.c
+++ b/src/compiler/ast_compiler.c
@@ -6,10 +6,11 @@
 #include "core.h"
 #include "opcode.h"
 #include "utils.h"
-#include "vm.h"
 #include <string.h>
 
-#include "ast_printer.h"
+#if defined(DUMP_AST_WHEN_COMPILE_PROG)
+    #include "ast_printer.h"
+#endif
 
 // 保存需要释放的local-var的name
 // 使用的位置：class 中静态变量名创建后需添加进入该列表追踪

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -45,6 +45,8 @@ struct KeywordToken keywords[] = {
     SET(import, IMPORT),
     SET(in, IN),
     SET(native, NATIVE),
+    SET(getter, GETTER),
+    SET(setter, SETTER),
     {NULL, 0, TOKEN_UNKNOWN},
 };
 #undef SET

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -1,9 +1,7 @@
 #ifndef __PARSER_PARSER_H__
 #define __PARSER_PARSER_H__
 
-#include "common.h"
-#include "compiler.h"
-#include "meta_obj.h"
+#include "sparrow.h"
 
 typedef enum {
     TOKEN_UNKNOWN,
@@ -66,6 +64,9 @@ typedef enum {
 
     // OTHER MARK
     TOKEN_QUESTION,
+
+    // GETTER & SETTER
+    TOKEN_GETTER, TOKEN_SETTER,
 
     // UN-PRINTABLE MARK
     TOKEN_EOF,

--- a/test/test_getter_and_setter.sp
+++ b/test/test_getter_and_setter.sp
@@ -1,0 +1,26 @@
+class A {
+    getter setter static let name = "<Class A>";
+    getter setter let field;
+    new() {
+        field = 10;
+    }
+}
+
+if A.name != "<Class A>" {
+    Thread.abort("getter error: A.name = %(A.name)");
+}
+
+A.name = 10;
+if A.name != 10 {
+    Thread.abort("setter error: A.name = %(A.name)");
+}
+
+let a = A.new();
+if a.field != 10 {
+    Thread.abort("getter error: a.field = %(a.field)");
+}
+
+a.field = -999;
+if a.field != -999 {
+    Thread.abort("setter error: a.field = %(a.field)");
+}


### PR DESCRIPTION
为 ast-compiler 实现了 getter 和 setter 修饰符，可修饰类字段。自动为被修饰的字段生成 getter 方法、setter 方法。

test:
- 添加 getter & setter 的功能测试。

2025-09-14
Closed #39