### PR TITLE
feat (parser ast test) 为 ast-compiler 添加 loop 语法糖

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -798,6 +798,15 @@ void compile_while_stmt(Parser* parser, AST_WhileStmt* res) {
     compile_block(parser, res->body);
 }
 
+void compile_loop_stmt(Parser* parser, AST_WhileStmt* res) {
+    res->condition = malloc(sizeof(AST_Expr));
+    res->condition->type = AST_LITERAL_TRUE;
+
+    res->body = malloc(sizeof(AST_Block));
+    consume_cur_token(parser, TOKEN_LC, "expect '{' for while body start.");
+    compile_block(parser, res->body);
+}
+
 void compile_for_stmt(Parser* parser, AST_Block* res) {
     consume_cur_token(parser, TOKEN_ID, "expect id for loop variable name.");
     
@@ -937,6 +946,9 @@ AST_Stmt* compile_stmt(Parser* parser) {
     } else if (match_token(parser, TOKEN_WHILE)) {
         res->type = AST_WHILE_STMT;
         compile_while_stmt(parser, &res->stmt.while_stmt);
+    } else if (match_token(parser, TOKEN_LOOP)) {
+        res->type = AST_WHILE_STMT;
+        compile_loop_stmt(parser, &res->stmt.while_stmt);
     } else if (match_token(parser, TOKEN_FOR)) {
         // for 在此处直接去糖
         res->type = AST_BLOCK;

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -47,6 +47,7 @@ struct KeywordToken keywords[] = {
     SET(native, NATIVE),
     SET(getter, GETTER),
     SET(setter, SETTER),
+    SET(loop, LOOP),
     {NULL, 0, TOKEN_UNKNOWN},
 };
 #undef SET

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -68,6 +68,8 @@ typedef enum {
     // GETTER & SETTER
     TOKEN_GETTER, TOKEN_SETTER,
 
+    TOKEN_LOOP,
+
     // UN-PRINTABLE MARK
     TOKEN_EOF,
 } TokenType;

--- a/test/test_loop_syntax.sp
+++ b/test/test_loop_syntax.sp
@@ -1,0 +1,12 @@
+let i = 0;
+
+loop {
+    if i >= 10 {
+        break;
+    }
+    i = i + 1;
+}
+
+if i != 10 {
+    Thread.abort("loop error: i = %(i)");
+}


### PR DESCRIPTION
如题。

`loop {}` 即为 `while true {}` 的简略形式。
由于 ast-compiler 会优化循环条件，因此 loop 不会产生冗余的条件判断与跳转代码。

2025-09-14