### PR TITLE
feat (ast test) 为 ast-compiler 添加自动属性构造器语法

### DIFF
--- a/test/test_auto_property_constructor.sp
+++ b/test/test_auto_property_constructor.sp
@@ -1,0 +1,21 @@
+class A {
+    getter let a: i32;
+    getter let b: String?;
+    getter let c: Map<String, Any>;
+
+    new{a: i32, b: String?, c: Map<String, Any>}() {}
+    
+    new{a: i32, b: String?}() {
+        c = {
+            "a": a,
+            "b": b,
+        };
+    }
+
+    to_string() -> String {
+        return "<a: %(a), b: %(b), c: %(c)>";
+    }
+}
+
+let a = A.new(10, "this is b");
+System.print(a);


### PR DESCRIPTION
主要工作：
添加了自动属性构造器 (auto property constructor) 语法。
test 添加了测试 auto-property-constructor 是否正常工作的测试用例。

自动属性构造器:
- 简化构造函数 `new` 的书写；
- 解决了构造函数型参不能和字段重名导致可读性差的问题。 它具有如下语法：
```
// 代码无实际含义，仅作语法展示
class A {
    let a: i32;
    let b: String?;
    let c: List<i32>;

    new{a: i32, b: String?}(val: i32) {
        c = [a, val];
    }

    new{a: i32, b, c}() {} // 型参列表和函数体全不可省略
}
```
以上代码将展开为：
```
class A {
    let a: i32;
    let b: String?;
    let c: List<i32>;

    new(new@a: i32, new@b: String?, val: i32) { // 此处 new@ 前缀用于处理重名问题
        a = new@a;
        b = new@b;
        c = [a, val];
    }

    new(new@a: i32, new@b, new@c) {
        a = new@a;
        b = new@b;
        c = new@c;
    }
}
```
该语法展开于 ast 生成时完成，可通过 DUMP_AST_WHEN_COMPILE_PROG 检查生成语法树是否正确。

本次提交可通过所有 test 中的功能测试。

2025-09-17